### PR TITLE
Update pwdhash-safari.js

### DIFF
--- a/pwdhash-safari.safariextension/pwdhash-safari.js
+++ b/pwdhash-safari.safariextension/pwdhash-safari.js
@@ -74,7 +74,6 @@ function PwdhashSafariPasswordElement(el) {
     function keydownListener(e) {
         // check whether hash is needed, don't clear
         if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey || navKeyCodes.indexOf(e.keyCode) !== -1) {
-            replaceValue();
             return;
         }
         // clear value if modifying a hashed password


### PR DESCRIPTION
there is a bug when you press i.e. shift to insert an uppercase letter but it adds three characters (key code for shift obviously) plus the uppercase letter generating a flash hash of course.
removing this fixed it for me.
unfortunately I do not own a certificate so I can't build it :(
could you rebuild the extension?
